### PR TITLE
New FreeBSD support + fix setup.py

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -42,6 +42,31 @@ Building and Installing
   To run the test suite, in the directory containing this file run:
     make test
 
+Building and Installing FreeBSD
+-----------------------
+
+  The build dependencies are:
+    - Python2 development system, http://www.python.org
+    - A POSIX system (make, unix shell, sed, etc).
+    - gcc >= 5
+    - The PAM development libraries,
+      http://pam.sourceforge.net
+
+  In addition the unit test requires:
+    - sudo, http://www.sudo.ws/
+    - An account with root privileges.
+
+  To build the re-distributable, in the directory containing
+  this file run:
+    gmake
+
+  To install, in the directory containing this file run:
+    gmake install
+
+  To run the test suite, in the directory containing this file run:
+    gmake test
+  
+  PAM module pam_python.so will be installed in /usr/local/lib/security path
 
 License
 -------

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,3 +1,7 @@
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),FreeBSD)
+        PREFIX ?= /usr/local
+endif
 PREFIX	?= /usr
 DOCDIR	?= $(PREFIX)/share/doc/pam_python
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -3,6 +3,11 @@ all:	ctest pam_python.so test-pam_python.pam
 WARNINGS=-Wall -Wextra -Wundef -Wshadow -Wpointer-arith -Wbad-function-cast -Wsign-compare -Waggregate-return -Wstrict-prototypes -Wmissing-prototypes -Wmissing-declarations -Werror
 #WARNINGS=-Wunreachable-code 	# Gcc 4.1 .. 4.4 are too buggy to make this useful
 
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),FreeBSD)
+        LIBDIR ?= /usr/local/lib/security
+endif
+
 LIBDIR ?= /lib/security
 
 pam_python.so: pam_python.c setup.py Makefile

--- a/src/pam_python.c
+++ b/src/pam_python.c
@@ -29,7 +29,7 @@
 #define PAM_SM_PASSWORD
 
 #include <security/pam_modules.h>
-#ifndef __APPLE__
+#if !defined(__APPLE__) && !defined(__FreeBSD__)
 #include <security/_pam_macros.h>
 #include <security/_pam_types.h>
 #else
@@ -51,8 +51,10 @@
 #endif
 
 #ifndef	DEFAULT_SECURITY_DIR
-#ifdef __APPLE__
+#if defined(__APPLE__)
 #define DEFAULT_SECURITY_DIR	"/usr/lib/pam/"
+#elif defined(__FreeBSD__)
+#define DEFAULT_SECURITY_DIR    "/usr/lib/"
 #else
 #define	DEFAULT_SECURITY_DIR	"/lib/security/"
 #endif
@@ -1927,7 +1929,7 @@ static PyObject* PamHandle_fail_delay(
 {
   int			err;
   int			micro_sec = 0;
-  int			pam_result;
+  /*int			pam_result; */
   PyObject*		result = 0;
   static char*		kwlist[] = {"micro_sec", NULL};
 

--- a/src/setup.py
+++ b/src/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -W default
+#!/usr/bin/env -S python2.7 -W default
 import warnings; warnings.simplefilter('default')
 
 import distutils.sysconfig
@@ -25,7 +25,9 @@ classifiers = [
   "Topic :: Software Development :: Libraries :: Python Modules",
   "Topic :: System :: Systems Administration :: Authentication/Directory"]
 
-if not os.environ.has_key("Py_DEBUG"):
+#if not os.environ.has_key("Py_DEBUG"):
+# fixed for python3 compatibility
+if not 'Py_DEBUG' in os.environ:
   Py_DEBUG = []
 else:
   Py_DEBUG = [('Py_DEBUG',1)]


### PR DESCRIPTION
Added support to build under FreeBSD with gcc >=5. To build use gmake instead of make.
(tested with gcc5, gcc7 and ggc8)
Fixed use of os.environ to be complaint with Python3